### PR TITLE
secure workflow

### DIFF
--- a/.github/workflows/unmanaged_dependency_check.yaml
+++ b/.github/workflows/unmanaged_dependency_check.yaml
@@ -17,6 +17,6 @@ jobs:
           # repository
           .kokoro/build.sh
       - name: Unmanaged dependency check
-        uses: googleapis/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@google-cloud-shared-dependencies/v3.32.0
+        uses: googleapis/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@google-cloud-shared-dependencies/v3.33.0
         with:
           bom-path: google-cloud-logging-bom/pom.xml

--- a/.kokoro/presubmit/graalvm-native-17.cfg
+++ b/.kokoro/presubmit/graalvm-native-17.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:3.32.0"
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:3.33.0"
 }
 
 env_vars: {

--- a/.kokoro/presubmit/graalvm-native.cfg
+++ b/.kokoro/presubmit/graalvm-native.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:3.32.0"
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:3.33.0"
 }
 
 env_vars: {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [3.20.0](https://github.com/googleapis/java-logging/compare/v3.19.0...v3.20.0) (2024-08-02)
+
+
+### Features
+
+* Enable hermetic library generation ([#1620](https://github.com/googleapis/java-logging/issues/1620)) ([034b9c4](https://github.com/googleapis/java-logging/commit/034b9c42ac8ba12f20dbde9e90ae8e59ea4c5748))
+
+
+### Dependencies
+
+* Update dependency com.google.cloud:sdk-platform-java-config to v3.33.0 ([#1664](https://github.com/googleapis/java-logging/issues/1664)) ([cb6de76](https://github.com/googleapis/java-logging/commit/cb6de767ba726a1178b4ebd0b481a4fc2454b910))
+
+
+### Documentation
+
+* Documentation update for OpenTelemetry and tracing ([#1657](https://github.com/googleapis/java-logging/issues/1657)) ([e3c6670](https://github.com/googleapis/java-logging/commit/e3c667094170ac7d404addc797facbe997ca51d3))
+
 ## [3.19.0](https://github.com/googleapis/java-logging/compare/v3.18.0...v3.19.0) (2024-06-26)
 
 

--- a/generation_config.yaml
+++ b/generation_config.yaml
@@ -1,6 +1,6 @@
-gapic_generator_version: 2.42.0
-googleapis_commitish: 6f289d775912966eb0cf04bda91e5e355c998d30
-libraries_bom_version: 26.38.0
+gapic_generator_version: 2.43.0
+googleapis_commitish: d8fce50eea92bac3a6612ee61559989ce3b38776
+libraries_bom_version: 26.43.0
 libraries:
   - api_shortname: logging
     name_pretty: Cloud Logging

--- a/generation_config.yaml
+++ b/generation_config.yaml
@@ -1,5 +1,5 @@
 gapic_generator_version: 2.43.0
-googleapis_commitish: d8fce50eea92bac3a6612ee61559989ce3b38776
+googleapis_commitish: c37b7f00ae5b9ce0d33ae28473d993cdaa5550cb
 libraries_bom_version: 26.43.0
 libraries:
   - api_shortname: logging

--- a/google-cloud-logging-bom/pom.xml
+++ b/google-cloud-logging-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-logging-bom</artifactId>
-  <version>3.19.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
+  <version>3.20.0</version><!-- {x-version-update:google-cloud-logging:current} -->
   <packaging>pom</packaging>
   <parent>
     <groupId>com.google.cloud</groupId>
@@ -53,17 +53,17 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-logging</artifactId>
-        <version>3.19.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
+        <version>3.20.0</version><!-- {x-version-update:google-cloud-logging:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-logging-v2</artifactId>
-        <version>0.108.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
+        <version>0.109.0</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-logging-v2</artifactId>
-        <version>0.108.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
+        <version>0.109.0</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/google-cloud-logging-bom/pom.xml
+++ b/google-cloud-logging-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-logging-bom</artifactId>
-  <version>3.19.0</version><!-- {x-version-update:google-cloud-logging:current} -->
+  <version>3.19.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
   <packaging>pom</packaging>
   <parent>
     <groupId>com.google.cloud</groupId>
@@ -53,17 +53,17 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-logging</artifactId>
-        <version>3.19.0</version><!-- {x-version-update:google-cloud-logging:current} -->
+        <version>3.19.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-logging-v2</artifactId>
-        <version>0.108.0</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
+        <version>0.108.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-logging-v2</artifactId>
-        <version>0.108.0</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
+        <version>0.108.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/google-cloud-logging-bom/pom.xml
+++ b/google-cloud-logging-bom/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.8.0</version>
+    <version>1.9.1</version>
   </parent>
 
   <name>Google Cloud logging BOM</name>

--- a/google-cloud-logging/pom.xml
+++ b/google-cloud-logging/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-logging</artifactId>
-  <version>3.19.0</version><!-- {x-version-update:google-cloud-logging:current} -->
+  <version>3.19.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
   <packaging>jar</packaging>
   <name>Google Cloud Logging</name>
   <url>https://github.com/googleapis/java-logging</url>
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-logging-parent</artifactId>
-    <version>3.19.0</version><!-- {x-version-update:google-cloud-logging:current} -->
+    <version>3.19.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
   </parent>
   <properties>
     <site.installationModule>google-cloud-logging</site.installationModule>

--- a/google-cloud-logging/pom.xml
+++ b/google-cloud-logging/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-logging</artifactId>
-  <version>3.19.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
+  <version>3.20.0</version><!-- {x-version-update:google-cloud-logging:current} -->
   <packaging>jar</packaging>
   <name>Google Cloud Logging</name>
   <url>https://github.com/googleapis/java-logging</url>
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-logging-parent</artifactId>
-    <version>3.19.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
+    <version>3.20.0</version><!-- {x-version-update:google-cloud-logging:current} -->
   </parent>
   <properties>
     <site.installationModule>google-cloud-logging</site.installationModule>

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
@@ -40,7 +40,7 @@ public final class Instrumentation {
   // See
   // https://github.com/googleapis/release-please/blob/main/docs/customizing.md#updating-arbitrary-files
   // {x-version-update-start:google-cloud-logging:current}
-  public static final String DEFAULT_INSTRUMENTATION_VERSION = "3.19.0";
+  public static final String DEFAULT_INSTRUMENTATION_VERSION = "3.19.1-SNAPSHOT";
   // {x-version-update-end}
   public static final String INSTRUMENTATION_LOG_NAME = "diagnostic-log";
   public static final int MAX_DIAGNOSTIC_VALUE_LENGTH = 14;

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
@@ -40,7 +40,7 @@ public final class Instrumentation {
   // See
   // https://github.com/googleapis/release-please/blob/main/docs/customizing.md#updating-arbitrary-files
   // {x-version-update-start:google-cloud-logging:current}
-  public static final String DEFAULT_INSTRUMENTATION_VERSION = "3.19.1-SNAPSHOT";
+  public static final String DEFAULT_INSTRUMENTATION_VERSION = "3.20.0";
   // {x-version-update-end}
   public static final String INSTRUMENTATION_LOG_NAME = "diagnostic-log";
   public static final int MAX_DIAGNOSTIC_VALUE_LENGTH = 14;

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/v2/stub/ConfigServiceV2StubSettings.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/v2/stub/ConfigServiceV2StubSettings.java
@@ -24,6 +24,7 @@ import static com.google.cloud.logging.v2.ConfigClient.ListViewsPagedResponse;
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -690,6 +691,7 @@ public class ConfigServiceV2StubSettings extends StubSettings<ConfigServiceV2Stu
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "logging.googleapis.com:443";
   }

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/v2/stub/LoggingServiceV2StubSettings.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/v2/stub/LoggingServiceV2StubSettings.java
@@ -23,6 +23,7 @@ import static com.google.cloud.logging.v2.LoggingClient.ListMonitoredResourceDes
 import com.google.api.MonitoredResourceDescriptor;
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.batching.BatchingSettings;
 import com.google.api.gax.batching.FlowControlSettings;
 import com.google.api.gax.batching.FlowController;
@@ -449,6 +450,7 @@ public class LoggingServiceV2StubSettings extends StubSettings<LoggingServiceV2S
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "logging.googleapis.com:443";
   }

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/v2/stub/MetricsServiceV2StubSettings.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/v2/stub/MetricsServiceV2StubSettings.java
@@ -20,6 +20,7 @@ import static com.google.cloud.logging.v2.MetricsClient.ListLogMetricsPagedRespo
 
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
+import com.google.api.core.ObsoleteApi;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
@@ -217,6 +218,7 @@ public class MetricsServiceV2StubSettings extends StubSettings<MetricsServiceV2S
   }
 
   /** Returns the default service endpoint. */
+  @ObsoleteApi("Use getEndpoint() instead")
   public static String getDefaultEndpoint() {
     return "logging.googleapis.com:443";
   }

--- a/grpc-google-cloud-logging-v2/pom.xml
+++ b/grpc-google-cloud-logging-v2/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api.grpc</groupId>
   <artifactId>grpc-google-cloud-logging-v2</artifactId>
-  <version>0.108.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
+  <version>0.109.0</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
   <name>grpc-google-cloud-logging-v2</name>
   <description>GRPC library for grpc-google-cloud-logging-v2</description>
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-logging-parent</artifactId>
-    <version>3.19.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
+    <version>3.20.0</version><!-- {x-version-update:google-cloud-logging:current} -->
   </parent>
   <dependencies>
     <dependency>

--- a/grpc-google-cloud-logging-v2/pom.xml
+++ b/grpc-google-cloud-logging-v2/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api.grpc</groupId>
   <artifactId>grpc-google-cloud-logging-v2</artifactId>
-  <version>0.108.0</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
+  <version>0.108.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
   <name>grpc-google-cloud-logging-v2</name>
   <description>GRPC library for grpc-google-cloud-logging-v2</description>
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-logging-parent</artifactId>
-    <version>3.19.0</version><!-- {x-version-update:google-cloud-logging:current} -->
+    <version>3.19.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
   </parent>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>sdk-platform-java-config</artifactId>
-    <version>3.32.0</version>
+    <version>3.33.0</version>
   </parent>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.2</version>
         <reportSets>
           <reportSet>
             <reports>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-logging-parent</artifactId>
   <packaging>pom</packaging>
-  <version>3.19.0</version><!-- {x-version-update:google-cloud-logging:current} -->
+  <version>3.19.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
   <name>Google Cloud Logging Parent</name>
   <url>https://github.com/googleapis/java-logging</url>
   <description>
@@ -80,17 +80,17 @@
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-logging-v2</artifactId>
-        <version>0.108.0</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
+        <version>0.108.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-logging-v2</artifactId>
-        <version>0.108.0</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
+        <version>0.108.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-logging</artifactId>
-        <version>3.19.0</version><!-- {x-version-update:google-cloud-logging:current} -->
+        <version>3.19.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-logging-parent</artifactId>
   <packaging>pom</packaging>
-  <version>3.19.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
+  <version>3.20.0</version><!-- {x-version-update:google-cloud-logging:current} -->
   <name>Google Cloud Logging Parent</name>
   <url>https://github.com/googleapis/java-logging</url>
   <description>
@@ -80,17 +80,17 @@
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-logging-v2</artifactId>
-        <version>0.108.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
+        <version>0.109.0</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-logging-v2</artifactId>
-        <version>0.108.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
+        <version>0.109.0</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-logging</artifactId>
-        <version>3.19.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
+        <version>3.20.0</version><!-- {x-version-update:google-cloud-logging:current} -->
       </dependency>
 
       <dependency>

--- a/proto-google-cloud-logging-v2/pom.xml
+++ b/proto-google-cloud-logging-v2/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api.grpc</groupId>
   <artifactId>proto-google-cloud-logging-v2</artifactId>
-  <version>0.108.0</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
+  <version>0.108.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
   <name>proto-google-cloud-logging-v2</name>
   <description>PROTO library for proto-google-cloud-logging-v2</description>
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-logging-parent</artifactId>
-    <version>3.19.0</version><!-- {x-version-update:google-cloud-logging:current} -->
+    <version>3.19.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
   </parent>
   <dependencies>
     <dependency>

--- a/proto-google-cloud-logging-v2/pom.xml
+++ b/proto-google-cloud-logging-v2/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api.grpc</groupId>
   <artifactId>proto-google-cloud-logging-v2</artifactId>
-  <version>0.108.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
+  <version>0.109.0</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
   <name>proto-google-cloud-logging-v2</name>
   <description>PROTO library for proto-google-cloud-logging-v2</description>
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-logging-parent</artifactId>
-    <version>3.19.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
+    <version>3.20.0</version><!-- {x-version-update:google-cloud-logging:current} -->
   </parent>
   <dependencies>
     <dependency>

--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": [
+        "fileMatch": [
         "^.kokoro/presubmit/graalvm-native.*.cfg$"
       ],
       "matchStrings": ["value: \"gcr.io/cloud-devrel-public-resources/graalvm.*:(?<currentValue>.*?)\""],
@@ -30,7 +30,7 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^.github/workflows/unmanaged_dependency_check.yaml$"
+      "^.github/workflows/unmanaged_dependency_check.yaml$"
       ],
       "matchStrings": ["uses: googleapis/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@google-cloud-shared-dependencies/v(?<currentValue>.+?)\\n"],
       "depNameTemplate": "com.google.cloud:sdk-platform-java-config",

--- a/samples/native-image-sample/pom.xml
+++ b/samples/native-image-sample/pom.xml
@@ -121,7 +121,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin
             </artifactId> <!-- Must use older version of surefire plugin for native-image testing. -->
-            <version>3.2.5</version>
+            <version>3.3.1</version>
             <configuration>
               <includes>
                 <include>**/IT*</include>

--- a/samples/snapshot/pom.xml
+++ b/samples/snapshot/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-logging</artifactId>
-      <version>3.19.1-SNAPSHOT</version>
+      <version>3.20.0</version>
     </dependency>
     <!-- {x-version-update-end} -->
     <dependency>

--- a/samples/snapshot/pom.xml
+++ b/samples/snapshot/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-logging</artifactId>
-      <version>3.19.0</version>
+      <version>3.19.1-SNAPSHOT</version>
     </dependency>
     <!-- {x-version-update-end} -->
     <dependency>

--- a/versions.txt
+++ b/versions.txt
@@ -1,6 +1,6 @@
 # Format:
 # module:released-version:current-version
 
-google-cloud-logging:3.19.0:3.19.0
-grpc-google-cloud-logging-v2:0.108.0:0.108.0
-proto-google-cloud-logging-v2:0.108.0:0.108.0
+google-cloud-logging:3.19.0:3.19.1-SNAPSHOT
+grpc-google-cloud-logging-v2:0.108.0:0.108.1-SNAPSHOT
+proto-google-cloud-logging-v2:0.108.0:0.108.1-SNAPSHOT

--- a/versions.txt
+++ b/versions.txt
@@ -1,6 +1,6 @@
 # Format:
 # module:released-version:current-version
 
-google-cloud-logging:3.19.0:3.19.1-SNAPSHOT
-grpc-google-cloud-logging-v2:0.108.0:0.108.1-SNAPSHOT
-proto-google-cloud-logging-v2:0.108.0:0.108.1-SNAPSHOT
+google-cloud-logging:3.20.0:3.20.0
+grpc-google-cloud-logging-v2:0.109.0:0.109.0
+proto-google-cloud-logging-v2:0.109.0:0.109.0


### PR DESCRIPTION
- **feat: enable hermetic library generation (#1620)**
- **chore: skip hermetic generation on fork PRs (#1651)**
- **chore: make the owlbot postprocessor check non-required (#1654)**
- **chore: disable the Owl Bot post-processor (#1653)**
- **chore(deps): update dependency com.google.cloud:libraries-bom to v26.43.0 (#1642)**
- **docs: Documentation update for OpenTelemetry and tracing (#1657)**
- **build(deps): update dependency org.apache.maven.plugins:maven-project-info-reports-plugin to v3.6.2 (#1644)**
- **build(deps): update dependency com.google.cloud:google-cloud-shared-config to v1.9.1 (#1663)**
- **build(deps): update dependency org.apache.maven.plugins:maven-surefire-plugin to v3.3.1 (#1643)**
- **deps: update dependency com.google.cloud:sdk-platform-java-config to v3.33.0 (#1664)**
- **chore: Update generation configuration at Wed Jul 31 02:02:52 UTC 2024 (#1655)**
- **chore(main): release 3.19.1-SNAPSHOT (#1668)**
- **chore: Update generation configuration at Fri Aug  2 02:14:46 UTC 2024 (#1670)**
- **chore(main): release 3.20.0 (#1671)**
- **chore: secure hermetic build workflow**
